### PR TITLE
fix(sm70): warm prefill kernels to the resolved pool size

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2407,7 +2407,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # TileLang's paged-prefill cache key contains the request batch
                 # size.  Warm both the overwhelmingly common first-chat batch
                 # of one and the existing two-request shape before readiness.
-                max_warmup_bs = self.server_args.max_running_requests
+                #
+                # Warm up to the RESOLVED pool capacity (self.max_running_requests),
+                # not the raw user request (server_args.max_running_requests). For
+                # hybrid mamba/linear-attention models the mamba state-cache budget
+                # can resolve the capacity below the user request (e.g.
+                # --max-running-requests 2 resolves to 1 when the pool fits only
+                # one request), and warming a batch size the pool cannot hold
+                # crashes at startup. init_memory_pool() runs before
+                # kernel_warmup(), so self.max_running_requests already holds the
+                # resolved value.
+                max_warmup_bs = self.max_running_requests
                 warmup_batch_sizes = (
                     bs
                     for bs in (1, 2)


### PR DESCRIPTION
## Motivation

Starting the server with `--max-running-requests 2` crashes at startup for
hybrid mamba / linear-attention models (reproduced with `Qwen3.8-27B-FP8` on
SM70 V100, TP2).

The SM70 prefill warmup pre-warmed kernel batch sizes up to the concurrency the
*user requested* (`server_args.max_running_requests`). But the request pool is
sized to the *resolved* concurrency (`self.max_running_requests`), which for
these models can be smaller than the request: the mamba state-cache budget
clamps it (e.g. `--max-running-requests 2` resolves to 1 when the mamba pool
only fits one request). Warming a batch size the pool cannot hold overflows an
internal index buffer and crashes the server before it is ready.

The warmup line was also the only place in `model_runner.py` that read the raw
`server_args.max_running_requests`; the rest of the file uses the resolved
`self.max_running_requests`. So the warmup was both wrong and inconsistent with
the surrounding code.

## Modifications

`python/sglang/srt/model_executor/model_runner.py` — make the prefill warmup
use the resolved pool capacity (`self.max_running_requests`) instead of the raw
user request, matching the rest of the file. `init_memory_pool()` runs before
`kernel_warmup()`, so the resolved value is already set by the time the warmup
runs. The common `mr=1` path is unchanged (it still warms only batch size 1).

## Accuracy Tests

N/A — no change to model outputs or kernel math. The warmup only pre-compiles
kernels ahead of readiness; it does not affect numerics.

## Speed Tests and Profiling

No throughput change expected (the warmup is a one-time startup cost).

Local validation, 2x V100-32GB (TP2), `Qwen3.8-27B-FP8`, E5M2 KV,
`--max-running-requests 2 --context-length 262144 --max-total-tokens 262144`:

- **Before:** crashes at startup, never serves.
  ```
  RuntimeError: The expanded size of the tensor (1) must match the existing
  size (2) at non-singleton dimension 0.  Target sizes: [1].  Tensor sizes: [2]
  ```
  raised in `_fill_kv_indptr_and_indices` (triton_backend.py:374), reached via
  `kernel_warmup` -> `_warmup_prefill_kernels_extends` ->
  `init_forward_metadata`.
- **After:** starts cleanly (`The server is fired up and ready to roll!`),
  `GET /health` -> 200, `POST /v1/chat/completions` -> 200.

Note: with the default mamba budget the resolved capacity is 1, so this run
serves 1 concurrent request. Reaching 2 concurrent additionally requires
raising the mamba budget (`--max-mamba-cache-size 10`), which is a launch-config
choice and is not part of this code change.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
